### PR TITLE
Fix Android compilation error with RN 0.47

### DIFF
--- a/android/src/main/java/com/centaurwarchief/facebooklogin/FacebookLoginPackage.java
+++ b/android/src/main/java/com/centaurwarchief/facebooklogin/FacebookLoginPackage.java
@@ -22,9 +22,4 @@ public class FacebookLoginPackage implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext context) {
         return Collections.emptyList();
     }
-
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
 }


### PR DESCRIPTION
Method createJSModules was removed from RN 0.47. Which leads to compilation error due to @override annotation. This method can be removed right now (facebook/react-native#15232)